### PR TITLE
Error handling for too long messages

### DIFF
--- a/utils/bots/mktCommissions/mktCommissions.py
+++ b/utils/bots/mktCommissions/mktCommissions.py
@@ -260,6 +260,18 @@ class mktCommissions(commands.Cog):
 
                     else:
                         if count == 0:
+                            if len(message.content) > 900:
+                                embedTooLong = discord.Embed(
+                                    color=hexColors.red_error,
+                                    title="Message too long",
+                                    description=f"Please make sure that your message is no longer than 900 characters."
+                                )
+                                try:
+                                    await ctx.author.send(embed=embedTooLong)
+                                except:
+                                    return
+                                continue
+
                             goal = message.content
 
                             embedNextQuestion = discord.Embed(
@@ -268,6 +280,18 @@ class mktCommissions(commands.Cog):
                             )
 
                         elif count == 1:
+                            if len(message.content) > 900:
+                                embedTooLong = discord.Embed(
+                                    color=hexColors.red_error,
+                                    title="Message too long",
+                                    description=f"Please make sure that your message is no longer than 900 characters."
+                                )
+                                try:
+                                    await ctx.author.send(embed=embedTooLong)
+                                except:
+                                    return
+                                continue
+
                             information = message.content
 
                             embedNextQuestion = discord.Embed(
@@ -276,6 +300,18 @@ class mktCommissions(commands.Cog):
                             )
 
                         elif count == 2:
+                            if len(message.content) > 900:
+                                embedTooLong = discord.Embed(
+                                    color=hexColors.red_error,
+                                    title="Message too long",
+                                    description=f"Please make sure that your message is no longer than 900 characters."
+                                )
+                                try:
+                                    await ctx.author.send(embed=embedTooLong)
+                                except:
+                                    return
+                                continue
+
                             dates = message.content
 
                             embedNextQuestion = discord.Embed(
@@ -284,6 +320,18 @@ class mktCommissions(commands.Cog):
                             )
 
                         elif count == 3:
+                            if len(message.content) > 900:
+                                embedTooLong = discord.Embed(
+                                    color=hexColors.red_error,
+                                    title="Message too long",
+                                    description=f"Please make sure that your message is no longer than 900 characters."
+                                )
+                                try:
+                                    await ctx.author.send(embed=embedTooLong)
+                                except:
+                                    return
+                                continue
+
                             approver = message.content
 
                             embedNextQuestion = discord.Embed(
@@ -292,6 +340,18 @@ class mktCommissions(commands.Cog):
                             )
 
                         elif count == 4:
+                            if len(message.content) > 900:
+                                embedTooLong = discord.Embed(
+                                    color=hexColors.red_error,
+                                    title="Message too long",
+                                    description=f"Please make sure that your message is no longer than 900 characters."
+                                )
+                                try:
+                                    await ctx.author.send(embed=embedTooLong)
+                                except:
+                                    return
+                                continue
+
                             finalDesicion = message.content
 
                             embedNextQuestion = discord.Embed(
@@ -300,6 +360,18 @@ class mktCommissions(commands.Cog):
                             )
 
                         elif count == 5:
+                            if len(message.content) > 900:
+                                embedTooLong = discord.Embed(
+                                    color=hexColors.red_error,
+                                    title="Message too long",
+                                    description=f"Please make sure that your message is no longer than 900 characters."
+                                )
+                                try:
+                                    await ctx.author.send(embed=embedTooLong)
+                                except:
+                                    return
+                                continue
+
                             anything_else = message.content
                             break
 


### PR DESCRIPTION
**Discord Username and Tag**
Puncher#1111

**Describe the Changes You've Created**
Error handling for too long messages. For now on, the user's messages has to be 900 or less characters in order to go further at the commission request.

**Where are these changes going?**
Marketing Server

**Confirm that you have done the following:**
- [ ] Created a new folder for your bot under utils/bots/~
- [ ] Moved any events under the events folder. 
- [ ] Properly Documented the code changes
- [ ] DM'd Space for a new Documentation Page (for new commands)
- [x] Tested the New Files on your own and you confirm that the changes are bug free.