### PR TITLE
Tech commissions roles changes (bug fix)

### DIFF
--- a/utils/bots/TutorBot/cogs/TutorMain.py
+++ b/utils/bots/TutorBot/cogs/TutorMain.py
@@ -36,7 +36,7 @@ class TutorMain(commands.Cog):
                 for entry in query:
                     TutorSession = pytz.timezone("America/New_York").localize(entry.Date)
 
-                    result = time.strptime(f"{TutorSession.Date}", "%d %B, %Y")
+                    result = time.strptime(f"{TutorSession}", "%d %B, %Y")
                     ts = int(TutorSession.timestamp())
                     studentUser = await self.bot.fetch_user(entry.StudentID)
                     ListTen.append(


### PR DESCRIPTION
**Discord Username and Tag**
Puncher#1111

**Describe the Changes You've Created**
Renamed the select menu option from "Developer Team" to "Bot Developer Team" [this bug](https://gist.github.com/Space-Turtle0/1ac5fc5a2cd00cfabb58a4bcd59550b4) by getting the roles with `discord.Guild.get_role()` instead of `discord.utils.get()`.

**Where are these changes going?**
IT-Department

**Confirm that you have done the following:**
- [ ] Created a new folder for your bot under utils/bots/~
- [ ] Moved any events under the events folder. 
- [ ] Properly Documented the code changes
- [ ] DM'd Space for a new Documentation Page (for new commands)
- [ ] Tested the New Files on your own and you confirm that the changes are bug free.