### PR TITLE
Essay Ticket gspread bug fixes

### DIFF
--- a/core/common.py
+++ b/core/common.py
@@ -244,7 +244,7 @@ class MAIN_ID:
     ))
     cat_essayTicket = int(ConfigcatClient.MAIN_ID_CC.get_value("cat_essayticket", 854945037875806220))
     cat_languageTicket = int(ConfigcatClient.MAIN_ID_CC.get_value(
-        "cat_languageticket", 825917349558747166
+        "cat_languageticket", 800477414361792562
     ))
     cat_otherTicket = int(ConfigcatClient.MAIN_ID_CC.get_value("cat_otherticket", 825917349558747166))
     cat_privateVC = int(ConfigcatClient.MAIN_ID_CC.get_value("cat_privatevc", 776988961087422515))

--- a/utils/events/TicketDropdown.py
+++ b/utils/events/TicketDropdown.py
@@ -833,23 +833,26 @@ class DropdownTickets(commands.Cog):
             )
 
             if channel.category_id == MAIN_ID.cat_essayTicket:
-                authors = []
-                async for message in channel.history(limit=None):
-                    if (
-                        f"{message.author} ({message.author.id})" not in authors
-                        and not message.author.bot
-                    ):
-                        authors.append(f"{message.author} ({message.author.id})")
-
                 raw_url = S3_URL.split("](")[1].strip(")")
+                values = self.sheet.col_values(1)
 
-                authors.insert(0, raw_url)
-                authors.insert(1, "")  #
-                authors.insert(2, "")  #
-                authors.insert(3, "")  # because of connected cells
-                authors.insert(4, "")  #
-                authors.insert(5, "")  #
-                self.sheet.append_row(authors)
+                if raw_url not in values:
+                    authors = []
+                    async for message in channel.history(limit=None):
+                        if (
+                            f"{message.author} ({message.author.id})" not in authors
+                            and not message.author.bot
+                        ):
+                            authors.append(f"{message.author} ({message.author.id})")
+
+
+                    authors.insert(0, raw_url)
+                    authors.insert(1, "")  #
+                    authors.insert(2, "")  #
+                    authors.insert(3, "")  # because of connected cells
+                    authors.insert(4, "")  #
+                    authors.insert(5, "")  #
+                    self.sheet.append_row(authors)
 
             await msg.delete()
             await interaction.channel.send(
@@ -884,29 +887,26 @@ class DropdownTickets(commands.Cog):
             # print(transcript_file.filename)
 
             if channel.category_id == MAIN_ID.cat_essayTicket:
-                sa_creds = json.loads(os.getenv("GSPREADSJSON"))
-                creds = ServiceAccountCredentials.from_json_keyfile_dict(sa_creds, scope)
-                gspread_client = gspread.authorize(creds)
-                print("Connected to Gspread.")
-                sheet = gspread_client.open_by_key(essayTicketLog_key).sheet1
-
-                authors = []
-                async for message in channel.history(limit=None):
-                    if (
-                        f"{message.author} ({message.author.id})" not in authors
-                        and not message.author.bot
-                    ):
-                        authors.append(f"{message.author} ({message.author.id})")
-
                 raw_url = url.split("](")[1].strip(")")
+                values = self.sheet.col_values(1)
 
-                authors.insert(0, raw_url)
-                authors.insert(1, "")  #
-                authors.insert(2, "")  #
-                authors.insert(3, "")  # because of connected cells
-                authors.insert(4, "")  #
-                authors.insert(5, "")  #
-                sheet.append_row(authors)
+                if raw_url not in values:
+                    authors = []
+                    async for message in channel.history(limit=None):
+                        if (
+                            f"{message.author} ({message.author.id})" not in authors
+                            and not message.author.bot
+                        ):
+                            authors.append(f"{message.author} ({message.author.id})")
+
+
+                    authors.insert(0, raw_url)
+                    authors.insert(1, "")  #
+                    authors.insert(2, "")  #
+                    authors.insert(3, "")  # because of connected cells
+                    authors.insert(4, "")  #
+                    authors.insert(5, "")  #
+                    self.sheet.append_row(authors)
 
             try:
                 await msgO.edit(


### PR DESCRIPTION
**Discord Username and Tag**
Puncher#1111

**Describe the Changes You've Created**
For the google spreadsheet (https://docs.google.com/spreadsheets/d/1pB5xpsBGKIES5vmEY4hjluFg7-FYolOmN_w3s20yzr0/edit#gid=0) it will now only fill in transcripts for essay tickets. It also fills in only once per ticket. Also removed the hyperlink from the gspread.

**Where are these changes going?**
Main Server

**Confirm that you have done the following:**
- [ ] Created a new folder for your bot under utils/bots/~
- [ ] Moved any events under the events folder. 
- [ ] Properly Documented the code changes
- [ ] DM'd Space for a new Documentation Page (for new commands)
- [x] Tested the New Files on your own and you confirm that the changes are bug free.