### PR TITLE
Tech commission author read_messages access

### DIFF
--- a/utils/bots/CoreBot/cogs/techProject.py
+++ b/utils/bots/CoreBot/cogs/techProject.py
@@ -37,6 +37,9 @@ async def createChannel(
     await channel.set_permissions(
         ctx.guild.default_role, read_messages=False, reason="Ticket Perms"
     )
+    await channel.set_permissions(
+        member, read_messages=True, reason="Ticket Perms"
+    )
 
     for role in RolePerms:
         await channel.set_permissions(


### PR DESCRIPTION
**Discord Username and Tag**
Puncher#1111

**Describe the Changes You've Created**
At the moment, if someone creates a tech commission, the guy who submitted/author can't see the channel. Should get changed.

**Where are these changes going?**
IT Department

**Confirm that you have done the following:**
- [ ] Created a new folder for your bot under utils/bots/~
- [ ] Moved any events under the events folder. 
- [ ] Properly Documented the code changes
- [ ] DM'd Space for a new Documentation Page (for new commands)
- [x] Tested the New Files on your own and you confirm that the changes are bug free.