### PR TITLE
introduce the addTitle command

### DIFF
--- a/utils/events/chat_helper_ticket_sys.py
+++ b/utils/events/chat_helper_ticket_sys.py
@@ -1314,6 +1314,16 @@ class DropdownTickets(commands.Cog):
             > {Emoji.ss_arrow} Send a picture of your assignment title in your direct messages as per the bot instructions.""",
             view=TicketButton(self.bot),
         )
+    
+    @app_commands.command(
+        name="title", description="Prompts for assignment title."
+    )
+    @app_commands.guilds(MainID.g_main)
+    @slash_is_bot_admin()
+    async def sendTitle(self, interaction: discord.Interaction):
+        await interaction.response.send_message(
+            f"""Please send a screenshot of your assignment title so that the Helper team can confirm its not a quiz or test of any kind!"""
+        )
 
 
 async def setup(bot):


### PR DESCRIPTION
I do hope I used the decorators correctly for this cmd - its mostly ripped from the sendCHTKTView command.
Also - is line 1321 necessary? I left it in to be safe, but I fear it will restrict the domain of where the command can be used. 

**FILL OUT THE FIELDS BELOW!**

**Discord Username and Tag**
Ex: Ady#1286

**Describe the Changes You've Created**

Implementing a sendTitle command (requested by the Helper team) that will send a message in any channel it is called in. Could you check if line 1321 is necessary? I left it in to be safe, but I fear it will restrict the domain of where the command can be used. 
The general code for the command is mostly ripped from the sendCHTKTView with some features removed. 

**Where are these changes going?**

Main Server

**Confirm that you have done the following:**
- [x] Created a new folder for your bot under utils/bots/~
- [x] Moved any events under the events folder. 
- [x] Properly Documented the code changes
- [x] DM'd Space for a new Documentation Page (for new commands)
- [x] Tested the New Files on your own and you confirm that the changes are bug free.

**Additional Context**
Did not create a new folder or file as this command is too small to warrant it. 