### PR TITLE
added permissions to StaffApps for HR role

### DIFF
--- a/utils/bots/TicketSystem/view_models.py
+++ b/utils/bots/TicketSystem/view_models.py
@@ -682,6 +682,13 @@ class StaffApps(ui.Modal, title="Staff Applications"):
         )
 
         await channel.set_permissions(
+            HRID.r_hr_staff,
+            read_messages=True,
+            send_messages=True,
+            reason="Ticket Perms (HR Staff)",
+        )
+
+        await channel.set_permissions(
             interaction.user,
             read_messages=True,
             send_messages=True,


### PR DESCRIPTION
**Discord Username and Tag**
isobarbaric#4799

**Describe the Changes You've Created**
I have added an extra permission to the StaffApps class so the HR staff can view and edit staff application channels. This amend is in response to a bot commission requested by madeleine#0030 named **auto**.

**Where are these changes going?**
These changes are going to the HR Department server and will enable HR staff to view staff application channels.

**Confirm that you have done the following:**
- [x] Created a new folder for your bot under utils/bots/~
- [x] Moved any events under the events folder. 
- [x] Properly Documented the code changes
- [x] DM'd Space for a new Documentation Page (for new commands)
- [x] Tested the New Files on your own and you confirm that the changes are bug free.
